### PR TITLE
The "Decluttered Templates" Update

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,13 +1,4 @@
----
-name: Bug report
-about: Create a report to help us improve Chai
-title: ''
-labels: ''
-assignees: ''
-
----
-
-Bug report template
+<!-- Bug report template -->
 
 =User information=
 
@@ -24,7 +15,7 @@ Bug report template
 
 
 * UserID:
-(Optional / please note this helps devs fix issues much faster, and without it may result in the whatever bug being reported going undiscovered for longer.)
+<!-- (Optional / please note this helps devs fix issues much faster, and without it may result in the whatever bug being reported going undiscovered for longer.) -->
 
 --
 
@@ -42,17 +33,7 @@ Bug report template
 =Provide Screenshots if possible=
 
 
-
-
-
-
-
-
-
-
-To obtain your User ID:
-
-Step 1: Open Chai
+<!-- Step 1: Open Chai
 Step 2: Navigate over to your Account tab.
 Step 3: Inside of your Account tab - click on "Settings", which can be found at the bottom of your Accounts Tab.
 Step 4: Inside "Settings", you will find your User ID. You can tap on this to easily copy it.
@@ -64,4 +45,4 @@ Step 2: Navigate to the chat relevant to the bot you feel should be reported / i
 Step 3: Navigate to the top right of the screen, Tap on the Three Dots. 
 Step 4: Tap "Share" and copy the link.
 
-Example: chai.ml/chat/share/_bot_1122334455...
+Example: chai.ml/chat/share/_bot_1122334455... -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,4 +1,13 @@
-<!-- Bug report template -->
+---
+name: Bug report
+about: Create a report to help us improve Chai
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+Bug report template
 
 =User information=
 

--- a/.github/ISSUE_TEMPLATE/chai-bot-reports--do-not-include-screenshots-.md
+++ b/.github/ISSUE_TEMPLATE/chai-bot-reports--do-not-include-screenshots-.md
@@ -9,29 +9,22 @@ assignees: ''
 
 ---
 
-Bot ID / Share Link:    
+<!-- Thank you for helping keep Chai clean!
 
-To obtain this, open the chat relevant to the bot you feel should be reported. 
+Please note, policy violations include: 
+- NSFW of fictional minors. Incest bots.
+- Rape bots.
+- Serial killers (In real life) 
+- Any type of disturbing profile pictures ranging from CP or Gore. 
+- Racist bots.
+- Pedophilia/Groomer bots. -->
+
+Bot ID / Share Link:
+
+<!-- To obtain this, open the chat relevant to the bot you feel should be reported. 
 After this, navigate to the top right of the screen, Tap on the Three Dots, Tap "Share", and copy the link.
-Example: chai.ml/chat/share/_bot_1122334455...
+Example: chai.ml/chat/share/_bot_1122334455... -->
 
+Bot Creator Name:  
 
-
-Bot Creator Name:    
-
-
-
-Please provide a brief description of how this is in violation if necessary: 
-
-
-
-Thank you for helping keep Chai clean!
-
-
-Policy violations include: 
-NSFW of fictional minors. Incest bots.
-Rape bots.
-Serial killers (In real life) 
-Any type of disturbing profile pictures ranging from CP or Gore. 
-Racist bots.
-Pedophilia/Groomer bots.
+Please provide a brief description of how this is in violation if necessary:


### PR DESCRIPTION
Two of the three templates were full of unnecessary information, such as instructions on how to links to this-or-that, making them frustrating for users to read.  These templates have been "de-cluttered" by making the comments directed at users hidden in the actual posts via "comment" HTML code.

This should make bug reports look a little nicer while still giving users all the information they need for proper report protocol.